### PR TITLE
Created Listener ECS

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -102,7 +102,7 @@ resource "aws_ecs_task_definition" "railway-listener-task" {
         { name = "S3_BUCKET",  value = var.S3_BUCKET_NAME },
 
         { name = "DB_HOST", value = var.DB_HOST },
-        { name = "DB_PORT", value = tostring(var.DB_PORT) },
+        { name = "DB_PORT", value = var.DB_PORT },
         { name = "DB_NAME", value = var.DB_NAME },
 
         { name = "DB_USERNAME", value = var.DB_USERNAME },
@@ -181,7 +181,7 @@ resource "aws_ecs_task_definition" "railway-dashboard-task" {
         { name = "S3_BUCKET",  value = var.S3_BUCKET_NAME },
 
         { name = "DB_HOST", value = var.DB_HOST },
-        { name = "DB_PORT", value = tostring(var.DB_PORT) },
+        { name = "DB_PORT", value = var.DB_PORT },
         { name = "DB_NAME", value = var.DB_NAME },
 
         { name = "DB_USERNAME", value = var.DB_USERNAME },

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -2,4 +2,6 @@
 
 provider "aws" {
   region     = var.AWS_REGION
+  access_key = var.AWS_ACCESS_KEY_ID
+  secret_key = var.AWS_SECRET_ACCESS_KEY
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -37,14 +37,14 @@ variable "DASHBOARD_PORT" {
   default = 8501
 }
 
-# Database
+
 variable "DB_HOST" {
   type = string
 }
 
 variable "DB_PORT" {
-  type    = number
-  default = 5432
+  type    = string
+  default = "5432"
 }
 
 variable "DB_NAME" {
@@ -56,6 +56,16 @@ variable "DB_USERNAME" {
 }
 
 variable "DB_PASSWORD" {
+  type      = string
+  sensitive = true
+}
+
+variable "AWS_ACCESS_KEY_ID" {
+  type      = string
+  sensitive = true
+}
+
+variable "AWS_SECRET_ACCESS_KEY" {
   type      = string
   sensitive = true
 }


### PR DESCRIPTION
Closes #17 

## Description of Changes

Terraformed the Railway Tracker listener ECS service: 

- Added ECS Fargate task    
definition and service for the live incident listener
- Configured CloudWatch logging and ECS execution role
- Defined security group 
- Injected database and S3 configuration via environment variables

## Additional Notes

Removed AWS secret key and AWS access key id for security, users should receive the option to enter them when they run terraform apply.