### PR TITLE
Created lambda.tf script

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,0 +1,86 @@
+################### IAM Roles ###################
+
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "lambda_exec_role" {
+  name               = "c21-railway-lambda-exec-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+}
+
+# Basic CloudWatch logging
+resource "aws_iam_role_policy_attachment" "lambda_basic_logs" {
+  role       = aws_iam_role.lambda_exec_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+################### S3 Read/Write Policies ###################
+
+data "aws_iam_policy_document" "lambda_s3_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.S3_BUCKET_NAME}"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.S3_BUCKET_NAME}/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "lambda_s3" {
+  name   = "c21-railway-tracker-lambda-s3"
+  policy = data.aws_iam_policy_document.lambda_s3_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_s3_attach" {
+  role       = aws_iam_role.lambda_exec_role.name
+  policy_arn = aws_iam_policy.lambda_s3.arn
+}
+
+################### Lambda 1: Metrics Pipeline ###################
+
+resource "aws_lambda_function" "metrics" {
+  function_name = "c21-railway-tracker-metrics-pipeline"
+  role          = aws_iam_role.lambda_exec_role.arn
+
+  package_type = "Image"
+  image_uri    = var.METRICS_LAMBDA_IMAGE_URI
+
+  timeout     = 60
+  memory_size = 256
+}
+
+################### Lambda 2: Reporting/Archive ###################
+
+resource "aws_lambda_function" "reports" {
+   function_name = "c21-railway-tracker-reports-archiver"
+  role          = aws_iam_role.lambda_exec_role.arn
+
+  package_type = "Image"
+  image_uri    = var.REPORTS_LAMBDA_IMAGE_URI
+
+  timeout     = 60
+  memory_size = 256
+}
+

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -69,3 +69,11 @@ variable "AWS_SECRET_ACCESS_KEY" {
   type      = string
   sensitive = true
 }
+
+variable "METRICS_LAMBDA_IMAGE_URI" {
+  type = string
+}
+
+variable "REPORTS_LAMBDA_IMAGE_URI" {
+  type = string
+}


### PR DESCRIPTION
Closes #15 

## Description of Changes

- Added Terraform configuration for two AWS Lambda functions
- Implemented a metrics pipeline Lambda using a container image from ECR
- Implemented a reports and archiving Lambda using a container image from ECR

## Additional Notes

- Both Lambdas share a single execution role with CloudWatch logging and S3 read/write permissions
- Images must be built and pushed to ECR before running `terraform apply`.