### PR TITLE
Updated CI.yml to only install pytest and pylint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,10 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "**/*.py"
   workflow_dispatch:
+
 
 jobs:
   hello_world:


### PR DESCRIPTION
Closes #63 

## Description of Changes

- Updated ci.yml to install only pytest for the test job

- Updated ci.yml to install only pylint for the lint job

- Removed the pip install -r pipeline/requirements.txt step from both jobs

## Additional Notes

- Tests or linting may fail if the codebase requires additional third party dependencies that are not installed in CI