### PR TITLE
Store PDF Reports in S3 Bucket

### DIFF
--- a/report/upload_to_s3.py
+++ b/report/upload_to_s3.py
@@ -1,3 +1,27 @@
 """Script which uploads a generated PDF report to the S3 bucket."""
 
-import boto3
+from os import environ as ENV, _Environ
+
+from dotenv import load_dotenv
+from boto3 import client
+
+
+def get_s3_client(config: _Environ) -> client:
+    """Returns a live S3 client."""
+
+    return client(
+        "s3",
+        aws_access_key_id=config["AWS_ACCESS_KEY"],
+        aws_secret_access_key=config["AWS_SECRET_KEY"]
+    )
+
+
+def upload_to_s3(s3_client: client, filename: str, bucket_name: str, object_name: str) -> None:
+    """Uploads a file to the S3 bucket."""
+
+    s3_client.upload_file(filename, bucket_name, object_name)
+
+
+if __name__ == "__main__":
+
+    load_dotenv()


### PR DESCRIPTION
Closes #74 

## Description of Changes

  - I added `upload_to_s3.py` as a helper script to upload PDF reports to the S3 bucket.
  - I changed `report.py` to upload PDF reports using functions from `upload_to_s3.py` to the S3 bucket before emailing.

## Additional Notes

None.