### PR TITLE
Dockerise Report

### DIFF
--- a/report/Dockerfile
+++ b/report/Dockerfile
@@ -1,0 +1,19 @@
+FROM public.ecr.aws/lambda/python:3.12
+
+RUN dnf install -y gcc
+
+RUN dnf install -y cairo-devel pkg-config python3-devel
+
+COPY requirements.txt .
+
+RUN pip3 install -r requirements.txt
+
+COPY upload_to_s3.py .
+
+COPY report_html.py .
+
+COPY metrics.py .
+
+COPY report.py .
+
+CMD ["report.handler"]

--- a/report/dockerise.sh
+++ b/report/dockerise.sh
@@ -1,0 +1,11 @@
+source .env
+
+export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com
+
+docker build -t ${AWS_ECR_REPO} . --platform "linux/amd64" --provenance=false
+
+docker tag ${AWS_ECR_REPO}:latest ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${AWS_ECR_REPO}:latest
+
+docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${AWS_ECR_REPO}:latest

--- a/report/requirements.txt
+++ b/report/requirements.txt
@@ -1,4 +1,4 @@
 xhtml2pdf
 python-dotenv
 boto3
-psycopg2
+psycopg2-binary


### PR DESCRIPTION
Closes #93 

## Description of Changes

  - I added a Dockerfile to detail how to make an image of the report.
  - I added `dockerise.sh` so that we can dockerise and upload an image of the report to the ECR simply by running `sh dockerise.sh`.
  - I changed `requirements.txt` to use `pyscopg2-binary` instead to work with dockerisation.

## Additional Notes

None.